### PR TITLE
Add unicode random write benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "vtebench"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -93,3 +93,26 @@ pub fn scrolling<W: Write>(ctx: &mut Context<W>, options: &Options) -> Result<us
 
     Ok(written)
 }
+
+pub fn unicode_random_write<W: Write>(ctx: &mut Context<W>, options: &Options) -> Result<usize> {
+    let mut written = 0;
+    let mut rng = rand::thread_rng();
+    let h = options.height;
+    let w = options.width;
+
+    while written < options.bytes {
+        let (l, c) = (rng.gen_range(0, h), rng.gen_range(0, w - 2));
+
+        written += ctx.cup(l, c)?;
+        if options.colorize {
+            written += ctx.setaf(rng.gen_range(0, 8))?;
+        }
+
+        let unicode_value = rng.gen_range(0, u16::max_value());
+        let unicode = String::from_utf16_lossy(&vec![unicode_value]).into_bytes();
+        ctx.write_all(&unicode)?;
+        written += unicode.len();
+    }
+
+    Ok(written)
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,12 @@ pub enum Benchmark {
     AltScreenRandomWrite,
 
     #[structopt(
+        name = "unicode-random-write",
+        about = "Repeatedly picks location and writes unicode character"
+    )]
+    UnicodeRandomWrite,
+
+    #[structopt(
         name = "scrolling-in-region",
         about = "Repeatedly outputs 'y\\n' within a scrolling region"
     )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ fn run() -> Result<()> {
     // Run the requested benchmark
     match options.benchmark {
         Benchmark::AltScreenRandomWrite => bench::alt_screen_random_write(&mut ctx, &options)?,
+        Benchmark::UnicodeRandomWrite => bench::unicode_random_write(&mut ctx, &options)?,
         Benchmark::ScrollingInRegion => bench::scrolling_in_region(&mut ctx, &options)?,
         Benchmark::Scrolling => bench::scrolling(&mut ctx, &options)?,
     };


### PR DESCRIPTION
This commit adds a benchmark which writes random unicode characters at
random positions on the screen.

Initially I didn't expect much difference to the normal random character
write in the alternate screen buffer, but apparently some terminals
really have issues with this.

It turns out alacritty is extremely slow with this on first run, but
then it gets better when running it again. Possibly because it needs to
find the glyphs and fonts.