### PR TITLE
fix: no params lead to error

### DIFF
--- a/generate-benchmarks.sh
+++ b/generate-benchmarks.sh
@@ -11,9 +11,11 @@ function generate_benchmark {
 
     # All remaining parameters are benchmark parameters
     params=""
-    for i in $(seq 3 $#); do
-        params+="${!i} "
-    done
+    if [ $# -gt 2]; then
+      for i in $(seq 3 $#); do
+          params+="${!i} "
+      done
+    fi
 
     # Target file path
     file="$target_dir/$benchname.vte"


### PR DESCRIPTION
I couldn't execute `generate-benchmarks.sh`, because vtebench was getting `$2` as a param.

The culprit here is the param collector, which, when no params are given (i.e. `$#` is 2) it makes a sequence from 3 to 2. (2 contains the benchname).

This PR fixes that