### PR TITLE
Update gnuplot scripts to work with older versions of bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ mkdir output/
 
 ### Requirements
 
-The scripts for plotting the benchmark data with `gnuplot` uses negative
-indexes for substrings. This was added in bash
+The scripts for plotting the benchmark data with `gnuplot` use negative
+indexes for substrings. This was added in `bash`
 [`4.2`](https://superuser.com/questions/1033273/bash-4-3-substring-negative-length-on-os-x#comment1442181_1033273).
 Ensure your version of bash is at least `4.2` by running:
 

--- a/README.md
+++ b/README.md
@@ -53,17 +53,6 @@ mkdir output/
 ./gnuplot/detailed.sh *.dat output/
 ```
 
-### Requirements
-
-The scripts for plotting the benchmark data with `gnuplot` use negative
-indexes for substrings. This was added in `bash`
-[`4.2`](https://superuser.com/questions/1033273/bash-4-3-substring-negative-length-on-os-x#comment1442181_1033273).
-Ensure your version of bash is at least `4.2` by running:
-
-```
-bash --version
-```
-
 ## Contributing Benchmarks
 
 If you have found benchmarks that might provide insightful information, or show

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cargo run --release -- --dat results.dat
 ```
 
 After having generated the `.dat` file, you can then pass it to a script in the
-`./gnuplot` directory script to generate the SVG plot:
+`./gnuplot` directory to generate the SVG plot:
 
 ```
 ./gnuplot/summary.sh results.dat output.svg

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ You can combine any number of results by passing them to the gnuplot script:
 And can plot detailed results using `detailed.sh`:
 
 ```
-mkdir output/
 ./gnuplot/detailed.sh *.dat output/
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,17 +33,35 @@ To do this you first need to output the benchmark results in the `.dat` format:
 cargo run --release -- --dat results.dat
 ```
 
-After having generated the `.dat` file, you can then pass it to the `gnuplot.sh`
-script to generate the SVG plot:
+After having generated the `.dat` file, you can then pass it to a script in the
+`./gnuplot` directory script to generate the SVG plot:
 
 ```
-./gnuplot.sh results.dat output.svg
+./gnuplot/summary.sh results.dat output.svg
 ```
 
 You can combine any number of results by passing them to the gnuplot script:
 
 ```
-./gnuplot.sh *.dat output.svg
+./gnuplot/summary.sh *.dat output.svg
+```
+
+And can plot detailed results using `detailed.sh`:
+
+```
+mkdir output/
+./gnuplot/detailed.sh *.dat output/
+```
+
+### Requirements
+
+The scripts for plotting the benchmark data with `gnuplot` uses negative
+indexes for substrings. This was added in bash
+[`4.2`](https://superuser.com/questions/1033273/bash-4-3-substring-negative-length-on-os-x#comment1442181_1033273).
+Ensure your version of bash is at least `4.2` by running:
+
+```
+bash --version
 ```
 
 ## Contributing Benchmarks

--- a/gnuplot/detailed.sh
+++ b/gnuplot/detailed.sh
@@ -42,7 +42,7 @@ for col in $(seq 1 $num_cols); do
             with linespoint \
             title \"$input_file: \".columnhead($col),"
     done
-    gnuplot_script=${gnuplot_script::-1}
+    gnuplot_script=${gnuplot_script::${#gnuplot_script}-1}
 
     # Plot everything.
     echo -e "$gnuplot_script" | gnuplot

--- a/gnuplot/summary.sh
+++ b/gnuplot/summary.sh
@@ -53,7 +53,7 @@ for column_label in $(cat "$1" | head -n 1); do
 
     index=$((index + 1))
 done
-gnuplot_tics="${gnuplot_tics::-1}) rotate by 315 left\n"
+gnuplot_tics="${gnuplot_tics::${#gnuplot_tics}-1}) rotate by 315 left\n"
 gnuplot_script+=$gnuplot_tics
 
 # Get the mean for all columns in every file.
@@ -67,7 +67,7 @@ for input_index in $(seq 1 $num_inputs); do
         title (col == 1 ? \"$input_file\" : \"\") \
         linecolor $input_index,"
 done
-gnuplot_script=${gnuplot_script::-1}
+gnuplot_script=${gnuplot_script::${#gnuplot_script}-1}
 
 # Plot everything.
 echo -e "$gnuplot_script" | gnuplot


### PR DESCRIPTION
**This PR**
Updates the `README` to include information about the new scripts for plotting with `gnuplot` - `summary.sh` and `detailed.sh` and updates them to work with versions of bash older than 4.2.

**Why?**
The `README` references a `./gnuplot.sh` script that seems to have been removed in favor of two other scripts - `summary.sh` and `detailed.sh` that are located in `./gnuplot` so I updated the language to point users there.

I ran into [an issue](https://github.com/alacritty/alacritty/pull/4331#issuecomment-714646236) while trying to plot the benchmarks on my machine that was due to having an older version of `bash` installed. This PR updates the substring syntax to not use negative indexes.