### PR TITLE
Initialize history before scrolling benchmarks

### DIFF
--- a/benchmarks/scrolling/setup
+++ b/benchmarks/scrolling/setup
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for _ in {0..100000}; do
+    printf "y\n"
+done

--- a/benchmarks/scrolling_fullscreen/setup
+++ b/benchmarks/scrolling_fullscreen/setup
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for _ in {0..100000}; do
+    printf "y\n"
+done

--- a/gnuplot/detailed.sh
+++ b/gnuplot/detailed.sh
@@ -4,13 +4,13 @@
 
 # Make sure gnuplot is installed.
 if ! [ -x "$(command -v gnuplot)" ]; then
-    echo "command not found: gnuplot"
+    printf "command not found: gnuplot\n"
     exit 1
 fi
 
 # Ensure at least one input and output file is present.
 if [ $# -lt 2 ]; then
-    echo "Usage: gnuplot.sh <INPUT_FILES>... <OUTPUT_DIRECTORY>"
+    printf "Usage: gnuplot.sh <INPUT_FILES>... <OUTPUT_DIRECTORY>\n"
     exit 1
 fi
 
@@ -45,5 +45,5 @@ for col in $(seq 1 $num_cols); do
     gnuplot_script=${gnuplot_script::${#gnuplot_script}-1}
 
     # Plot everything.
-    echo -e "$gnuplot_script" | gnuplot
+    printf "$gnuplot_script" | gnuplot
 done

--- a/gnuplot/summary.sh
+++ b/gnuplot/summary.sh
@@ -7,13 +7,13 @@ gap_size=2
 
 # Make sure gnuplot is installed.
 if ! [ -x "$(command -v gnuplot)" ]; then
-    echo "command not found: gnuplot"
+    printf "command not found: gnuplot\n"
     exit 1
 fi
 
 # Ensure at least one input and output file is present.
 if [ $# -lt 2 ]; then
-    echo "Usage: gnuplot.sh <INPUT_FILES>... <OUTPUT_FILE>"
+    printf "Usage: gnuplot.sh <INPUT_FILES>... <OUTPUT_FILE>\n"
     exit 1
 fi
 
@@ -70,4 +70,4 @@ done
 gnuplot_script=${gnuplot_script::${#gnuplot_script}-1}
 
 # Plot everything.
-echo -e "$gnuplot_script" | gnuplot
+printf "$gnuplot_script" | gnuplot


### PR DESCRIPTION
Since the scrolling benchmarks should be focused on the time it takes
to scroll content into history, not the time it takes to initialize the
history, 100,000 lines of history are first written to initialize
everything.

Generally since the initialization is only done once during program
execution, it should be largely irrelevant as long as it manages to do
so in a few milliseconds.