### PR TITLE
Optimize benchmark generation scripts

### DIFF
--- a/benchmarks/light_cells/benchmark
+++ b/benchmarks/light_cells/benchmark
@@ -6,10 +6,5 @@ columns=$(tput cols)
 lines=$(tput lines)
 
 for char in A B C D E F G H I J K L M N O P Q R S T U V W X Y Z; do
-    printf "\e[H"
-    for _ in $(seq $columns); do
-        for _ in $(seq $lines); do
-            printf $char
-        done
-    done
+    printf "\e[H%*s" $(($columns * $lines)) | tr ' ' "$char"
 done

--- a/benchmarks/scrolling_fullscreen/benchmark
+++ b/benchmarks/scrolling_fullscreen/benchmark
@@ -2,12 +2,8 @@
 
 # Scroll all lines up with every line completely filled.
 
-alphabet=(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z)
 columns=$(tput cols)
 
-for char in ${alphabet[@]}; do
-    for column in $(seq $columns); do
-        printf "$char"
-    done
-    printf "\n"
+for char in A B C D E F G H I J K L M N O P Q R S T U V W X Y Z; do
+    printf "%*s\n" $columns | tr ' ' "$char"
 done


### PR DESCRIPTION
This applies some minor optimization introduced by c0ee113 to other
benchmarks to speed up the generation of the terminal benchmarks.

Fixes #31.