### PR TITLE
Reduce the missing benchmark payload size

### DIFF
--- a/benchmarks/missing/benchmark
+++ b/benchmarks/missing/benchmark
@@ -6,7 +6,7 @@ columns=$(tput cols)
 lines=$(tput lines)
 
 # Assume private use area (0xE000 - 0xF8FF) results in "missing" glyphs.
-for i in $(seq 58000 58500); do
+for i in $(seq 58000 58200); do
     char=$(printf "\u$(printf '%04x' $i)")
     printf "\e[H%*s" $((2 * $columns * $lines)) | tr ' ' "$char"
 done


### PR DESCRIPTION
The missing glyph benchmark was exceptionally big compared to all other
benchmarks, causing it to stand out a bit in direct comparisons of all
benchmark results.

Having it a little smaller and more uniform with the other benchmarks
should help with getting a quick overview over the performance results.