### PR TITLE
Fix column/line retrieval in bash scripts

### DIFF
--- a/benchmarks/cursor_motion/benchmark
+++ b/benchmarks/cursor_motion/benchmark
@@ -2,8 +2,9 @@
 
 # Move cursor around for every single write.
 
-columns=$(tput cols)
-lines=$(tput lines)
+tty="/dev/$(ps -o tty= -p $$)"
+columns=$(tput cols < $tty)
+lines=$(tput lines < $tty)
 
 for char in A B C D E F G H I J K L M N O P Q R S T U V W X Y Z; do
     column_start=1

--- a/benchmarks/dense_cells/benchmark
+++ b/benchmarks/dense_cells/benchmark
@@ -2,8 +2,9 @@
 
 # Update the entire grid as often as possible with a huge payload in every cell.
 
-columns=$(tput cols)
-lines=$(tput lines)
+tty="/dev/$(ps -o tty= -p $$)"
+columns=$(tput cols < $tty)
+lines=$(tput lines < $tty)
 
 line_steps=1
 if [ $lines -lt 155 ]; then

--- a/benchmarks/light_cells/benchmark
+++ b/benchmarks/light_cells/benchmark
@@ -2,8 +2,9 @@
 
 # Update the entire grid as often as possible without scrolling.
 
-columns=$(tput cols)
-lines=$(tput lines)
+tty="/dev/$(ps -o tty= -p $$)"
+columns=$(tput cols < $tty)
+lines=$(tput lines < $tty)
 
 for char in A B C D E F G H I J K L M N O P Q R S T U V W X Y Z; do
     printf "\e[H%*s" $(($columns * $lines)) | tr ' ' "$char"

--- a/benchmarks/scrolling_bottom_region/setup
+++ b/benchmarks/scrolling_bottom_region/setup
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-lines=$(tput lines)
+tty="/dev/$(ps -o tty= -p $$)"
+lines=$(tput lines < $tty)
 
 printf "\e[?1049h\e[1;$((lines - 1))r"

--- a/benchmarks/scrolling_bottom_small_region/setup
+++ b/benchmarks/scrolling_bottom_small_region/setup
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-lines=$(tput lines)
+tty="/dev/$(ps -o tty= -p $$)"
+lines=$(tput lines < $tty)
 
 printf "\e[?1049h\e[1;$((lines / 2))r"

--- a/benchmarks/scrolling_fullscreen/benchmark
+++ b/benchmarks/scrolling_fullscreen/benchmark
@@ -2,7 +2,8 @@
 
 # Scroll all lines up with every line completely filled.
 
-columns=$(tput cols)
+tty="/dev/$(ps -o tty= -p $$)"
+columns=$(tput cols < $tty)
 
 for char in A B C D E F G H I J K L M N O P Q R S T U V W X Y Z; do
     printf "%*s\n" $columns | tr ' ' "$char"

--- a/benchmarks/scrolling_top_small_region/setup
+++ b/benchmarks/scrolling_top_small_region/setup
@@ -1,5 +1,6 @@
 #!/bin/sh
 
-lines=$(tput lines)
+tty="/dev/$(ps -o tty= -p $$)"
+lines=$(tput lines < $tty)
 
 printf "\e[?1049h\e[$((lines / 2));${lines}r"


### PR DESCRIPTION
In ncurses version 6.3 a change was made which means retrieving
columns/lines with just `tput lines/cols` isn't possible anymore. As a
solution the TTY is now passed to `tput`.

See ncurses mailing list:
https://lists.gnu.org/archive/html/bug-ncurses/2021-11/msg00030.html