### PR TITLE
Remove paths from graph legends

### DIFF
--- a/gnuplot/detailed.sh
+++ b/gnuplot/detailed.sh
@@ -37,10 +37,11 @@ for col in $(seq 1 $num_cols); do
     # Add all columns for the input file to the gnuplot script.
     for input_index in $(seq 1 $(($# - 1))); do
         input_file=${!input_index}
+        input_filename=$(basename "$input_file")
         gnuplot_script+="\"$input_file\" \
             using $col \
             with linespoint \
-            title \"$input_file: \".columnhead($col),"
+            title \"$input_filename: \".columnhead($col),"
     done
     gnuplot_script=${gnuplot_script::${#gnuplot_script}-1}
 

--- a/gnuplot/summary.sh
+++ b/gnuplot/summary.sh
@@ -60,11 +60,12 @@ gnuplot_script+=$gnuplot_tics
 gnuplot_script+="plot "
 for input_index in $(seq 1 $num_inputs); do
     input_file=${!input_index}
+    input_filename=$(basename "$input_file")
     num_cols=$(cat "$input_file" | head -n 1 | wc -w)
     gnuplot_script+="for[col = 1:${num_cols}] \
         \"$input_file\" \
         using (col * $bench_width + $((box_width * (input_index - 1)))):col \
-        title (col == 1 ? \"$input_file\" : \"\") \
+        title (col == 1 ? \"$input_filename\" : \"\") \
         linecolor $input_index,"
 done
 gnuplot_script=${gnuplot_script::${#gnuplot_script}-1}


### PR DESCRIPTION
Including the full file path is just unnecessary noise and would cause some legends to not show up at all.